### PR TITLE
import complete resource bundle to fix deep lookups

### DIFF
--- a/packages/gatsby-plugin-i18next/src/withI18next.js
+++ b/packages/gatsby-plugin-i18next/src/withI18next.js
@@ -25,7 +25,7 @@ const withI18next = (options = {}) => Comp => {
         data.locales.edges.forEach(({ node }) => {
           const { lng, ns, data } = node;
           if (!this.i18n.hasResourceBundle(lng, ns)) {
-            this.i18n.addResources(lng, ns, JSON.parse(data));
+            this.i18n.addResourceBundle(lng, ns, JSON.parse(data));
           }
         });
       }


### PR DESCRIPTION
{
    "key": "value of key",
    "look": {
        "deep": "value of look deep"
    }
}

import complete resource bundle so that "look.deep" works as translation.