### PR TITLE
fix context rewritten by plugin

### DIFF
--- a/packages/gatsby-i18n/src/plugin/onCreatePage.js
+++ b/packages/gatsby-i18n/src/plugin/onCreatePage.js
@@ -8,12 +8,15 @@ const onCreatePage = ({ page, actions }, pluginOptions) => {
     return Promise.resolve();
   }
 
+  const pageContext = { ...page.context, path: undefined };
+
   return new Promise(resolve => {
     const redirect = path.resolve('./.cache/@wapps/redirect.js');
     const redirectPage = {
       ...page,
       component: redirect,
       context: {
+        ...pageContext,
         availableLngs,
         fallbackLng,
         lng: null,
@@ -32,6 +35,7 @@ const onCreatePage = ({ page, actions }, pluginOptions) => {
         ...page,
         path: `/${lng}${page.path}`,
         context: {
+          ...pageContext,
           availableLngs,
           fallbackLng,
           lng,


### PR DESCRIPTION
The issue that this fixes:
When creating pages with `creagePage` on "gatsby-node.js",  the variables passed on `page.context` are overridden by gatsby-i18n.