### PR TITLE
add support for localized paths

### DIFF
--- a/packages/gatsby-i18n/src/Head.js
+++ b/packages/gatsby-i18n/src/Head.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 
 import { I18nConsumer } from './I18nContext';
+import { resolveLocalizedPath } from './utils';
+
 
 const defaultProps = {
   hreflang: true, // TODO https://github.com/nfl/react-helmet/issues/342
@@ -15,7 +17,10 @@ function Head({
   originalPath,
   siteUrl,
   hreflang,
+  localizedPaths,
 }) {
+  const resolvePath = resolveLocalizedPath(localizedPaths, originalPath);
+
   return (
     <>
       <Helmet>
@@ -25,7 +30,7 @@ function Head({
           <link
             key={value}
             rel="alternate"
-            href={`${siteUrl}${value}${originalPath}`}
+            href={`${siteUrl}${value}${resolvePath(value)}`}
             hreflang={value}
           />
         ))}

--- a/packages/gatsby-i18n/src/I18nContext.js
+++ b/packages/gatsby-i18n/src/I18nContext.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 const I18nContext = React.createContext();
 

--- a/packages/gatsby-i18n/src/Language.js
+++ b/packages/gatsby-i18n/src/Language.js
@@ -1,13 +1,16 @@
 import React, { Component } from 'react';
-import { navigate, withPrefix } from 'gatsby';
+import { navigate } from 'gatsby';
 
 import { I18nConsumer } from './I18nContext';
+import { resolveLocalizedPath } from './utils';
 
 class Language extends Component {
   handleChangeLng = newLng => {
-    const { originalPath } = this.props;
+    const { originalPath, localizedPaths } = this.props;
+    const resolvePath = resolveLocalizedPath(localizedPaths, originalPath);
+
     //const newUrl = withPrefix(`/${newLng}${originalPath}`);
-    const newUrl = `/${newLng}${originalPath}`;
+    const newUrl = `/${newLng}${resolvePath(newLng)}`;
     navigate(newUrl);
   };
 

--- a/packages/gatsby-i18n/src/Link.js
+++ b/packages/gatsby-i18n/src/Link.js
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types';
 import { Link as GatsbyLink } from 'gatsby';
 
 import { I18nConsumer } from './I18nContext';
+import { resolveLocalizedPath } from './utils';
 
-const Link = ({ to, lng, children, ...rest }) => {
+const Link = ({ to, lng, children, localizedPaths, ...rest }) => {
+  const resolvePath = resolveLocalizedPath(localizedPaths, to);
+
   return (
-    <GatsbyLink to={lng ? `/${lng}${to}` : `${to}`} {...rest}>
+    <GatsbyLink to={lng ? `/${lng}${resolvePath(lng)}` : `${to}`} {...rest}>
       {children}
     </GatsbyLink>
   );
@@ -18,5 +21,5 @@ Link.propTypes = {
 };
 
 export default props => (
-  <I18nConsumer>{({ lng }) => <Link lng={lng} {...props} />}</I18nConsumer>
+  <I18nConsumer>{({ lng, localizedPaths }) => <Link lng={lng} localizedPaths={localizedPaths} {...props} />}</I18nConsumer>
 );

--- a/packages/gatsby-i18n/src/Redirect.js
+++ b/packages/gatsby-i18n/src/Redirect.js
@@ -1,9 +1,9 @@
 import { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { withPrefix, navigate } from 'gatsby';
+import { navigate } from 'gatsby';
 import { lookup, navigatorLanguages } from 'langtag-utils';
 
 import { isBrowser } from './utils';
+import { resolveLocalizedPath } from './utils';
 
 class Redirect extends PureComponent {
   componentDidMount() {
@@ -11,7 +11,8 @@ class Redirect extends PureComponent {
   }
 
   perform = () => {
-    const { fallbackLng, availableLngs, redirectPage } = this.props.pageContext;
+    const { fallbackLng, availableLngs, redirectPage, localizedPaths } = this.props.pageContext;
+    const resolvePath = resolveLocalizedPath(localizedPaths, redirectPage);
 
     const detectedLng =
       window.localStorage.getItem('@wappsLng') ||
@@ -20,7 +21,7 @@ class Redirect extends PureComponent {
     window.localStorage.setItem('@wappsLng', detectedLng);
 
     //const newUrl = withPrefix(`/${detectedLng}${redirectPage}`);
-    const newUrl = `/${detectedLng}${redirectPage}`;
+    const newUrl = `/${detectedLng}${resolvePath(detectedLng)}`;
     navigate(newUrl, { replace: true });
   };
 

--- a/packages/gatsby-i18n/src/plugin/onCreatePage.js
+++ b/packages/gatsby-i18n/src/plugin/onCreatePage.js
@@ -1,8 +1,10 @@
 import path from 'path';
+import { resolveLocalizedPath } from '../utils';
 
 const onCreatePage = ({ page, actions }, pluginOptions) => {
   const { createPage, deletePage } = actions;
-  const { fallbackLng, availableLngs, siteUrl, i18nextOptions } = pluginOptions;
+  const { fallbackLng, availableLngs, siteUrl, i18nextOptions, localizedPaths = {} } = pluginOptions;
+  const resolvePath = resolveLocalizedPath(localizedPaths, page.path);
 
   if (page.path.includes('dev-404')) {
     return Promise.resolve();
@@ -24,6 +26,7 @@ const onCreatePage = ({ page, actions }, pluginOptions) => {
         redirectPage: page.path,
         siteUrl,
         i18nextOptions,
+        localizedPaths,
       },
     };
 
@@ -33,7 +36,7 @@ const onCreatePage = ({ page, actions }, pluginOptions) => {
     availableLngs.forEach(lng => {
       const localePage = {
         ...page,
-        path: `/${lng}${page.path}`,
+        path: `/${lng}${resolvePath(lng)}`,
         context: {
           ...pageContext,
           availableLngs,
@@ -43,6 +46,7 @@ const onCreatePage = ({ page, actions }, pluginOptions) => {
           originalPath: page.path,
           siteUrl,
           i18nextOptions,
+          localizedPaths,
         },
       };
 

--- a/packages/gatsby-i18n/src/utils.js
+++ b/packages/gatsby-i18n/src/utils.js
@@ -1,3 +1,13 @@
 export function isBrowser() {
   return typeof window === 'undefined';
 }
+
+export const resolveLocalizedPath = (localizedPaths = {}, path) => (lang) => {
+  const localizedPath = localizedPaths[path] || localizedPaths[path.split(0, path.length - 2)];
+
+  if (!localizedPath) {
+    return path;
+  }
+
+  return localizedPath[lang] || path;
+}

--- a/starters/gatsby-starter-i18next/gatsby-config.js
+++ b/starters/gatsby-starter-i18next/gatsby-config.js
@@ -29,7 +29,13 @@ module.exports = {
         siteUrl: 'https://www.example.com/',
         i18nextOptions: {
           debug: false,
-        },
+        }, // opitonal for localizing page paths
+        localizedPaths: {
+          '/page-2/': {
+            en: '/page-two/',
+            de: '/page-zwei/'
+          }
+        }
       },
     },
     'gatsby-plugin-offline',

--- a/starters/gatsby-starter-lingui/gatsby-config.js
+++ b/starters/gatsby-starter-lingui/gatsby-config.js
@@ -27,6 +27,13 @@ module.exports = {
         availableLngs: ['en', 'de'],
         fallbackLng: 'en',
         siteUrl: 'https://www.example.com/',
+        // opitonal for localizing page paths
+        localizedPaths: {
+          '/page-2/': {
+            en: '/page-two/',
+            de: '/page-zwei/'
+          }
+        }
       },
     },
     //'gatsby-plugin-offline',


### PR DESCRIPTION
Add support to localize paths.
1. Give localzedPaths object through gatsby-config to the plugin.
2. create resolver for localized URL
3. onPageCreate modify the URL accordingly or use the default + inject the localized paths for later use
4. Refactored Link, Head, Redirect, Language and Context to use localized paths
5. Added examples to both starter projects.