### PR TITLE
fix: nested JSON files not being added correctly

### DIFF
--- a/packages/gatsby-plugin-i18next/src/withI18next.js
+++ b/packages/gatsby-plugin-i18next/src/withI18next.js
@@ -25,7 +25,7 @@ const withI18next = (options = {}) => Comp => {
         data.locales.edges.forEach(({ node }) => {
           const { lng, ns, data } = node;
           if (!this.i18n.hasResourceBundle(lng, ns)) {
-            this.i18n.addResources(lng, ns, JSON.parse(data));
+            this.i18n.addResourceBundle(lng, ns, JSON.parse(data), true);
           }
         });
       }


### PR DESCRIPTION
When using a JSON structure with nested keys, e.g.
```json
{
  "rootKey": "Value",
  "category" : {
    "nestedKey": "This doesn't work currently"
  }
}

```
the current code is using `addResources` which seems to support on key/value pairs (docs [here](https://www.i18next.com/overview/api#addresources). By changing this to `addResourceBundle` it is possible to add support for key/value pairs using this plugin